### PR TITLE
feat: preset process.env.NODE_ENV as development

### DIFF
--- a/packages/svrx-cli/bin/svrx.js
+++ b/packages/svrx-cli/bin/svrx.js
@@ -6,6 +6,8 @@ const updateNotifier = require('update-notifier');
 const pkg = require('../package.json');
 const Manager = require('../lib');
 
+process.env.NODE_ENV = process.env.NODE_ENV || 'development';
+
 const PAD_START = 4;
 const PAD_END = 20;
 const printErrorAndExit = (error) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines         
- [ ] Tests for the changes have been added (for bug fixes / features)          
- [ ] Docs have been added / updated (for bug fixes / features)                      

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

`process.env.NODE_ENV` is widely used in Node world, for svrx mainly working in dev mode, it's friendly to preset it to `development`.

Besides, it can't work without `process.env.NODE_ENV` in project created by CRA:

![image](https://user-images.githubusercontent.com/2230882/65510462-92abab80-df07-11e9-8572-69adc24fb8b3.png)


* **What is the related issue?** (Use `#issue_id` to relate an open issue)



* **Does this PR introduce a breaking change?** 



* **Other information**:
